### PR TITLE
Change repository to non-SSB link

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
   "license": "MIT",
   "dependencies": {
     "looper": "^4.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/dominictarr/pull-paramap/issues"
+  },
+  "main": "index.js",
+  "directories": {
+    "test": "test"
   }
 }


### PR DESCRIPTION
Problem: I'm working on a project that doesn't use Git-SSB and I want to be able to `git clone` the source code for all of my dependencies.

Solution: Use a non-Git-SSB repository URI. I ran `npm init` and it resolved the problem(s) in `package.js`on.

---

On second thought, it looks like maybe the `repository` link is fine but npm just needs a publish?